### PR TITLE
Bump comfygit-core 0.3.20 → 0.3.21, manager 0.0.23 → 0.0.24

### DIFF
--- a/js/comfygit-panel.js
+++ b/js/comfygit-panel.js
@@ -22240,7 +22240,7 @@ const kE = { class: "settings-content" }, bE = { class: "settings-section" }, $E
     ariaLabel: "View ComfyGit Documentation",
     iconPath: "M8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"
   }
-], u7 = "v0.0.23", d7 = "Akatz", m7 = { class: "social-buttons" }, f7 = ["title", "aria-label", "onClick"], v7 = {
+], u7 = "v0.0.24", d7 = "Akatz", m7 = { class: "social-buttons" }, f7 = ["title", "aria-label", "onClick"], v7 = {
   width: "14",
   height: "14",
   viewBox: "0 0 16 16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "comfygit-manager"
-version = "0.0.23"
+version = "0.0.24"
 description = "ComfyGit Manager - Node for managing comfygit environments in ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "comfygit-core==0.3.20",
+    "comfygit-core==0.3.21",
     "watchdog>=6.0.0",
     "xxhash>=3.5.0",
     "zeroconf>=0.131.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "ComfyGit Manager - Node for managing comfygit environments in Com
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "comfygit-core==0.3.21",
+    "comfygit-core==0.3.22",
     "watchdog>=6.0.0",
     "xxhash>=3.5.0",
     "zeroconf>=0.131.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfygit-core==0.3.20
+comfygit-core==0.3.21
 watchdog>=6.0.0
 xxhash>=3.5.0
 zeroconf>=0.131.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfygit-core==0.3.21
+comfygit-core==0.3.22
 watchdog>=6.0.0
 xxhash>=3.5.0
 zeroconf>=0.131.0


### PR DESCRIPTION
## Summary

- Bump comfygit-core dependency from 0.3.20 to 0.3.21 (UV overlay system release)
- Bump manager version from 0.0.23 to 0.0.24
- Rebuilt frontend bundle to match new version

## Test plan

- [ ] Verify manager loads correctly with comfygit-core 0.3.21
- [ ] Confirm no overlay API surface changes break manager functionality