### PR TITLE
Release Manager 0.1.3

### DIFF
--- a/js/comfygit-panel.js
+++ b/js/comfygit-panel.js
@@ -24383,7 +24383,7 @@ const fT = { class: "remote-url-display" }, mT = ["title"], vT = ["title"], pT =
     ariaLabel: "View ComfyGit Documentation",
     iconPath: "M8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"
   }
-], Ko = "v0.1.2", W7 = "Akatz", G7 = { class: "social-buttons" }, j7 = ["title", "aria-label", "onClick"], H7 = {
+], Ko = "v0.1.3", W7 = "Akatz", G7 = { class: "social-buttons" }, j7 = ["title", "aria-label", "onClick"], H7 = {
   width: "14",
   height: "14",
   viewBox: "0 0 16 16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "comfygit-manager"
-version = "0.1.2"
+version = "0.1.3"
 description = "ComfyGit Manager - Node for managing comfygit environments in ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "comfygit-core==0.4.1",
+    "comfygit-core==0.4.2",
     "watchdog>=6.0.0",
     "xxhash>=3.5.0",
     "zeroconf>=0.131.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfygit-core==0.4.1
+comfygit-core==0.4.2
 watchdog>=6.0.0
 xxhash>=3.5.0
 zeroconf>=0.131.0

--- a/server/api/v2/update_manager.py
+++ b/server/api/v2/update_manager.py
@@ -10,6 +10,7 @@ from aiohttp import web
 
 from cgm_core.decorators import logged_operation
 from cgm_utils.async_helpers import run_sync
+from .update_check import _get_cached_latest_release
 
 routes = web.RouteTableDef()
 
@@ -27,10 +28,15 @@ _MANUAL_INSTRUCTIONS = (
 async def update_manager(request: web.Request, env) -> web.Response:
     """Update comfygit-manager using comfygit-core and return restart instructions."""
     try:
+        target_version = "latest"
+        cached_release = await _get_cached_latest_release()
+        if cached_release and cached_release.latest_version:
+            target_version = cached_release.latest_version
+
         # Prefer the dedicated manager update flow (handles legacy migration).
         update_manager_fn = getattr(env, "update_manager", None)
         if callable(update_manager_fn):
-            result = await run_sync(update_manager_fn, version="latest")
+            result = await run_sync(update_manager_fn, version=target_version)
             changed = bool(getattr(result, "changed", False))
             old_version = getattr(result, "old_version", None)
             new_version = getattr(result, "new_version", None)
@@ -74,4 +80,3 @@ async def update_manager(request: web.Request, env) -> web.Response:
                 "manual_instructions": _MANUAL_INSTRUCTIONS,
             }
         )
-

--- a/testing/integration/panel/test_update_notice_endpoints.py
+++ b/testing/integration/panel/test_update_notice_endpoints.py
@@ -88,9 +88,21 @@ class TestUpdateCheckEndpoint:
 
 @pytest.mark.integration
 class TestUpdateManagerEndpoint:
-    async def test_success_update_manager(self, client, mock_environment):
+    async def test_success_update_manager(self, client, mock_environment, monkeypatch):
         """Should call env.update_manager and return restart_required=true."""
         # Arrange
+        import api.v2.update_check as update_check_module
+        monkeypatch.setattr(update_check_module, "_cached_latest", None)
+        monkeypatch.setattr(
+            update_check_module,
+            "_fetch_latest_release_from_github",
+            lambda: {
+                "latest_version": "0.0.21",
+                "release_url": "https://github.com/comfygit-ai/comfygit-manager/releases/tag/v0.0.21",
+                "changelog_summary": None,
+            },
+        )
+
         result = type(
             "ManagerUpdateResult",
             (),
@@ -101,7 +113,13 @@ class TestUpdateManagerEndpoint:
                 "message": "Updated from 0.0.20 → 0.0.21",
             },
         )()
-        mock_environment.update_manager = lambda version="latest": result
+        called = {"version": None}
+
+        def fake_update_manager(version="latest"):
+            called["version"] = version
+            return result
+
+        mock_environment.update_manager = fake_update_manager
 
         # Act
         resp = await client.post("/v2/comfygit/update")
@@ -115,9 +133,14 @@ class TestUpdateManagerEndpoint:
         assert data["new_version"] == "0.0.21"
         assert data["restart_required"] is True
         assert data["manual_instructions"] is None
+        assert called["version"] == "0.0.21"
 
-    async def test_fallback_to_update_node(self, client, mock_environment):
+    async def test_fallback_to_update_node(self, client, mock_environment, monkeypatch):
         """Should fall back to env.update_node when update_manager is unavailable."""
+        import api.v2.update_check as update_check_module
+        monkeypatch.setattr(update_check_module, "_cached_latest", None)
+        monkeypatch.setattr(update_check_module, "_fetch_latest_release_from_github", lambda: (_ for _ in ()).throw(RuntimeError("offline")))
+
         # Arrange: make update_manager non-callable
         mock_environment.update_manager = None
 
@@ -149,8 +172,12 @@ class TestUpdateManagerEndpoint:
         assert data["status"] == "success"
         assert data["changed"] is True
 
-    async def test_failure_returns_manual_instructions(self, client, mock_environment):
+    async def test_failure_returns_manual_instructions(self, client, mock_environment, monkeypatch):
         """Should return a JSON error with manual instructions on failure."""
+        import api.v2.update_check as update_check_module
+        monkeypatch.setattr(update_check_module, "_cached_latest", None)
+        monkeypatch.setattr(update_check_module, "_fetch_latest_release_from_github", lambda: (_ for _ in ()).throw(RuntimeError("offline")))
+
         def boom(version="latest"):
             raise RuntimeError("update failed")
 
@@ -161,4 +188,3 @@ class TestUpdateManagerEndpoint:
         data = await resp.json()
         assert data["status"] == "error"
         assert data["manual_instructions"]
-

--- a/uv.lock
+++ b/uv.lock
@@ -401,7 +401,7 @@ wheels = [
 
 [[package]]
 name = "comfygit-core"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -413,14 +413,14 @@ dependencies = [
     { name = "uv" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/01/e10c5b81906af01ff08ada40dbf60d5e7a082e81283f3eda320a1726c3f9/comfygit_core-0.4.1.tar.gz", hash = "sha256:dd8caeb1ba04c62502eff79fcac808ce09b17113b9b6d38cee4a4e090a727ab2", size = 722626, upload-time = "2026-05-21T04:05:17.84Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/b6/a813b99af9413b7f95137ff36ebd1a00363d2f41b7f2490705182a230aa0/comfygit_core-0.4.2.tar.gz", hash = "sha256:df5edec39e4ed984ccc22be5f70e3842532157da29c40214fb6e4ab9c63a6d07", size = 723633, upload-time = "2026-05-21T05:58:55.2Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/76/de2f922f855aee85cff0a73732df975379457321f2bacd6f4fb5610ce4a3/comfygit_core-0.4.1-py3-none-any.whl", hash = "sha256:01710de79a0245a3e5ae49dbfd287261372e724bb5e242881fea55d7e03bd3d4", size = 434808, upload-time = "2026-05-21T04:05:16.455Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/184c2f700e0553000f4ddcddc01a4e062b05edda84a68df91ec6e574973f/comfygit_core-0.4.2-py3-none-any.whl", hash = "sha256:df7f1a76e992b49a509f08ea21dbec23706bb95b733ca2c35efaab07820c5074", size = 435258, upload-time = "2026-05-21T05:58:56.905Z" },
 ]
 
 [[package]]
 name = "comfygit-manager"
-version = "0.1.2"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "comfygit-core" },
@@ -441,7 +441,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "comfygit-core", specifier = "==0.4.1" },
+    { name = "comfygit-core", specifier = "==0.4.2" },
     { name = "watchdog", specifier = ">=6.0.0" },
     { name = "xxhash", specifier = ">=3.5.0" },
     { name = "zeroconf", specifier = ">=0.131.0" },


### PR DESCRIPTION
## Summary

- Bump comfygit-manager to 0.1.3 and pin `comfygit-core==0.4.2` in both `pyproject.toml` and `requirements.txt`.
- Route manager self-update through the GitHub release version instead of relying on a potentially stale registry latest response.
- Rebuild the panel bundle so the footer reports `v0.1.3`.

## Root Cause

Manager 0.1.1/0.1.2 could show an update from GitHub Releases while the actual update path used Comfy Registry latest metadata. During registry propagation this could read stale `0.1.1` data, or proceed to 0.1.2 and hit the old core updater bug. Core 0.4.2 fixes the updater transaction ordering; this release points Manager at that fixed core package.

## Upgrade Notes

Users already on a broken manager self-updater may need to update through ComfyGit panel -> Nodes / ComfyUI Manager, or manually change the tracked `comfygit-manager` node to the latest registry version and restart. Once Manager 0.1.3 is installed, future self-updates should use the explicit GitHub release target.

## Validation

- `uv run scripts/sync-requirements.py`
- `uv lock --refresh-package comfygit-core`
- `cd frontend && npm run build`
- `./scripts/check-frontend-version.sh`
- `uv run pytest testing/integration/panel/test_update_notice_endpoints.py::TestUpdateManagerEndpoint -q`
- `uv run ruff check server/api/v2/update_manager.py testing/integration/panel/test_update_notice_endpoints.py`
- `npm --prefix frontend run test:run -- src/composables/__tests__/useComfyGitService.updateNotice.test.ts`
